### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/io.github.Bavarder.Bavarder.json
+++ b/io.github.Bavarder.Bavarder.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.Bavarder.Bavarder",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "bavarder",
     "finish-args": [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.